### PR TITLE
refactor(Writer): change dependencies to ALL_FILES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## [1.1.0-alpha] - 2025-05-17
+## [1.2.0-alpha] - 2025-05-17
+### Fixes
+- When change one file had problem https://github.com/AntonButov/dagger-dsl/issues/91
 
+## [1.1.0-alpha] - 2025-05-17
 ### Fixes
 - Provides module error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [1.2.0-alpha] - 2025-05-17
 ### Fixes
-- When change one file had problem https://github.com/AntonButov/dagger-dsl/issues/91
+- Fix issue when changing a single file ([#91](https://github.com/AntonButov/dagger-dsl/issues/91))
 
 ## [1.1.0-alpha] - 2025-05-17
 ### Fixes

--- a/dagger-dsl-processor/src/main/kotlin/usecases/Writer.kt
+++ b/dagger-dsl-processor/src/main/kotlin/usecases/Writer.kt
@@ -42,7 +42,7 @@ class WriterImpl(private val codeGenerator: CodeGenerator) : Writer {
             .build()
             .writeTo(
                 codeGenerator = codeGenerator,
-                dependencies = Dependencies(aggregating = true, sources = arrayOf(file)),
+                dependencies = Dependencies.ALL_FILES,
             )
     }
 
@@ -58,7 +58,7 @@ class WriterImpl(private val codeGenerator: CodeGenerator) : Writer {
             .build()
             .writeTo(
                 codeGenerator = codeGenerator,
-                dependencies = Dependencies(aggregating = true, sources = arrayOf(file)),
+                dependencies = Dependencies.ALL_FILES,
             )
     }
 }


### PR DESCRIPTION
Update Writer.kt to use Dependencies.ALL_FILES instead of aggregating dependencies per file for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue related to file change detection improving reliability when modifying source files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->